### PR TITLE
feat: add pre-commit hooks and Claude Code setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git branch:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(find:*)",
+      "Bash(make lint:*)",
+      "Bash(make fmt:*)",
+      "Bash(pre-commit run:*)",
+      "Bash(uv run:*)",
+      "Bash(kubectl get:*)",
+      "Bash(kubectl describe:*)",
+      "Bash(kubectl logs:*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,8 @@
       "Bash(make lint:*)",
       "Bash(make fmt:*)",
       "Bash(pre-commit run:*)",
-      "Bash(uv run:*)",
+      "Bash(uv run python a2a_agent.py:*)",
+      "Bash(uv run python server.py:*)",
       "Bash(kubectl get:*)",
       "Bash(kubectl describe:*)",
       "Bash(kubectl logs:*)"

--- a/.claude/skills/commit.md
+++ b/.claude/skills/commit.md
@@ -1,0 +1,35 @@
+# Commit Conventions
+
+## Format
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+Signed-off-by: Your Name <email>
+Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>
+```
+
+## Types
+
+- `feat`: new feature or agent capability
+- `fix`: bug fix
+- `chore`: maintenance, deps, config
+- `docs`: documentation only
+- `test`: test additions or changes
+- `refactor`: code restructuring without behavior change
+
+## Scopes
+
+- `agents/k8s-debug` — k8s debugging agent
+- `agents/src-analyzer` — source code analyzer agent
+- `tools/a2a-bridge` — A2A-to-MCP bridge
+- `tools/k8s-readonly` — K8s read-only tool server
+- `deploy` — Kubernetes manifests
+
+## Rules
+
+- DCO sign-off required: `git commit -s`
+- Subject line ≤ 72 chars
+- No Co-Authored-By; use Assisted-By for AI assistance

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,19 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ["--unsafe"]
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+      - id: check-merge-conflict
+      - id: mixed-line-ending
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.1
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# agentic-control-plane
+
+## Overview
+
+A multi-agent demo showcasing AI agents as first-class Kubernetes citizens that collaborate to manage, monitor, and troubleshoot cluster workloads. Agents communicate via the A2A protocol, are discovered through AgentCard CRDs, and are bridged to supervisors via MCP.
+
+## Repository Structure
+
+```
+agentic-control-plane/
+├── agents/
+│   ├── k8s_debug_agent/        # AG2-based K8s debugging agent (A2A)
+│   └── source_code_analyzer/   # AG2-based source code analysis agent (A2A)
+├── tools/
+│   ├── a2a_bridge_server/      # MCP-to-A2A bridge (agent discovery + invocation)
+│   └── k8s_readonly_server/    # K8s read-only MCP tool server
+└── deploy/                     # Kubernetes manifests (kustomize)
+```
+
+## Key Commands
+
+| Task | Command |
+|------|---------|
+| Lint | `make lint` |
+| Format | `make fmt` |
+| Install pre-commit | `pre-commit install` |
+| Run agent (k8s-debug) | `cd agents/k8s_debug_agent && uv run python a2a_agent.py` |
+| Run agent (src-analyzer) | `cd agents/source_code_analyzer && uv run python a2a_agent.py` |
+| Run bridge | `cd tools/a2a_bridge_server && uv run python server.py` |
+| Deploy to K8s | `kubectl apply -k deploy/<component>/` |
+
+## Code Style
+
+- Python 3.10+, `uv` package manager
+- `ruff` for linting and formatting (line-length: 100)
+- Pre-commit hooks: `pre-commit install`
+- DCO sign-off required: `git commit -s`
+
+## Protocols
+
+- **A2A**: Agent-to-Agent (Google) — agents expose `/.well-known/agent.json`
+- **MCP**: Model Context Protocol — bridge translates MCP ↔ A2A
+- **AgentCard CRD**: Kubernetes CR caching agent capabilities for discovery
+
+## Architecture
+
+The supervisor (Claude Code or in-cluster agent) discovers running agents via the A2A bridge, which reads AgentCard CRDs created by the kagenti-operator. Agents expose skills that the supervisor delegates to for K8s operations and code analysis.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: lint fmt help
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+lint: ## Run all pre-commit hooks
+	pre-commit run --all-files
+
+fmt: ## Format Python code with ruff
+	ruff format .
+	ruff check --fix .

--- a/agents/k8s_debug_agent/pyproject.toml
+++ b/agents/k8s_debug_agent/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "ruff>=0.6.4",
-    "black>=24.4.2",
     "pre-commit>=3.7.1",
 ]
 
@@ -24,13 +23,3 @@ server = "a2a_agent:run"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.ruff]
-line-length = 100
-target-version = "py310"
-
-[tool.ruff.lint]
-extend-select = ["I"]
-
-[tool.black]
-line-length = 100
-target-version = ["py310"]

--- a/agents/source_code_analyzer/pyproject.toml
+++ b/agents/source_code_analyzer/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "ruff>=0.6.4",
-    "black>=24.4.2",
     "pre-commit>=3.7.1",
 ]
 
@@ -24,13 +23,3 @@ server = "a2a_agent:run"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.ruff]
-line-length = 100
-target-version = "py310"
-
-[tool.ruff.lint]
-extend-select = ["I"]
-
-[tool.black]
-line-length = 100
-target-version = ["py310"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "W"]


### PR DESCRIPTION
## Summary

Phase 1 of repo orchestration: establishes the code quality baseline.

- **`.pre-commit-config.yaml`** — root-level hooks: `ruff` lint+format, trailing whitespace, EOF fixer, YAML check, large file guard
- **`pyproject.toml`** — ruff config (line-length: 100, py310 target, E/F/I/W rules) shared across all sub-projects
- **`Makefile`** — `make lint` (runs pre-commit) and `make fmt` (ruff format + fix)
- **`CLAUDE.md`** — repo overview, structure map, key commands for contributors and AI assistants
- **`.claude/settings.json`** — safe Claude Code permission allowlist
- **`.claude/skills/commit.md`** — commit message conventions (types, scopes, DCO requirement)

## Test plan

- [ ] `pre-commit install` then `pre-commit run --all-files` passes
- [ ] `make lint` runs cleanly
- [ ] `make fmt` formats Python files without errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)