### PR TITLE
feat: add security governance (CODEOWNERS, SECURITY.md, CONTRIBUTING.md)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# CODEOWNERS — reviewers are automatically requested on pull requests.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: maintainers review everything
+* @kagenti/maintainers
+
+# CI / platform tooling
+.github/ @kagenti/maintainers
+Makefile @kagenti/maintainers
+pyproject.toml @kagenti/maintainers
+
+# Agents
+agents/ @kagenti/maintainers
+
+# Tools / bridge server
+tools/ @kagenti/maintainers
+
+# Kubernetes manifests
+deploy/ @kagenti/maintainers
+
+# Documentation
+*.md @kagenti/maintainers
+docs/ @kagenti/maintainers

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,13 @@ coverage.xml
 # OS files
 .DS_Store
 Thumbs.db
+
+# Secrets and credentials — never commit these
+*.key
+*.pem
+*.p12
+*.jks
+credentials.*
+secrets.*
+*kubeconfig*
+kubeconfig

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,152 @@
+# Contributing to agentic-control-plane
+
+Thank you for contributing! This guide covers how to set up your development
+environment, run tests, and submit pull requests.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.10+ (3.11 for `k8s_debug_agent`, 3.12 for `a2a_bridge_server`)
+- [`uv`](https://docs.astral.sh/uv/) — package and virtualenv manager
+- [`pre-commit`](https://pre-commit.com/) — local quality gates
+
+### Getting started
+
+```bash
+# Clone the repo
+git clone https://github.com/kagenti/agentic-control-plane.git
+cd agentic-control-plane
+
+# Install pre-commit hooks (run once)
+pre-commit install
+
+# Install dependencies for a specific subproject
+cd tools/a2a_bridge_server
+uv sync --frozen --extra dev
+
+cd agents/k8s_debug_agent
+uv sync --frozen --extra dev
+```
+
+## Project Structure
+
+```
+agentic-control-plane/
+├── agents/
+│   ├── k8s_debug_agent/       # AG2-based K8s debugging agent (A2A)
+│   └── source_code_analyzer/  # AG2-based source code analysis agent (A2A)
+├── tools/
+│   ├── a2a_bridge_server/     # MCP-to-A2A bridge (agent discovery + invocation)
+│   └── k8s_readonly_server/   # K8s read-only MCP tool server
+└── deploy/                    # Kubernetes manifests (kustomize)
+```
+
+## Running Tests
+
+Each subproject has its own test suite managed with `uv`:
+
+```bash
+# a2a bridge server
+cd tools/a2a_bridge_server
+uv run pytest tests/ -v
+
+# k8s debug agent
+cd agents/k8s_debug_agent
+uv run pytest tests/ -v
+```
+
+## Running Lint and Format Checks
+
+```bash
+# Run all pre-commit hooks on staged files
+pre-commit run
+
+# Or run on all files
+make lint
+
+# Auto-format
+make fmt
+```
+
+## Pull Request Process
+
+1. **Fork** the repository and create a feature branch from `main`:
+   ```bash
+   git checkout -b feat/my-feature main
+   ```
+
+2. **Make your changes** with accompanying tests.
+
+3. **Run checks locally** before pushing:
+   ```bash
+   pre-commit run --all-files
+   cd tools/a2a_bridge_server && uv run pytest tests/ -v
+   cd agents/k8s_debug_agent && uv run pytest tests/ -v
+   ```
+
+4. **Commit** with a DCO sign-off (required — see below):
+   ```bash
+   git commit -s -m "feat: describe your change"
+   ```
+
+5. **Push** and open a pull request against `main`. Fill in the PR template
+   and link any related issues.
+
+6. **CI must pass** before a PR can be merged. Address any failures before
+   requesting review.
+
+## Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+| Prefix | When to use |
+|--------|-------------|
+| `feat:` | New feature or capability |
+| `fix:` | Bug fix |
+| `docs:` | Documentation only |
+| `refactor:` | Code restructuring without behavior change |
+| `test:` | Adding or updating tests |
+| `chore:` | Build, tooling, or dependency updates |
+| `ci:` | CI/CD workflow changes |
+
+Examples:
+```
+feat: add streaming support to a2a bridge
+fix: handle missing Synced condition in AgentCard CRD
+docs: update README with Kind deployment steps
+```
+
+## DCO Sign-Off (Required)
+
+All commits must include a Developer Certificate of Origin sign-off:
+
+```bash
+git commit -s -m "feat: my change"
+# Adds: Signed-off-by: Your Name <your@email.com>
+```
+
+Pull requests without DCO sign-off will fail the DCO check in CI.
+To retroactively sign off all commits on your branch:
+
+```bash
+git rebase --signoff main
+```
+
+## Code Style
+
+- **Python 3.10+** with type hints where practical
+- **Ruff** for linting and formatting (line length: 100, target: Python 3.10)
+- Pre-commit hooks enforce style automatically on commit
+
+## Reporting Bugs
+
+Open a [GitHub Issue](https://github.com/kagenti/agentic-control-plane/issues/new)
+with:
+- A clear description of the problem
+- Steps to reproduce
+- Expected vs. actual behavior
+- Relevant logs or error messages
+
+For **security vulnerabilities**, see [SECURITY.md](SECURITY.md) — do not
+open a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ environment, run tests, and submit pull requests.
 
 ### Prerequisites
 
-- Python 3.10+ (3.11 for `k8s_debug_agent`, 3.12 for `a2a_bridge_server`)
+- Python 3.10+ (`k8s_debug_agent` requires ≥3.10; `a2a_bridge_server` requires ≥3.12; CI tests with 3.11 and 3.12 respectively)
 - [`uv`](https://docs.astral.sh/uv/) — package and virtualenv manager
 - [`pre-commit`](https://pre-commit.com/) — local quality gates
 
@@ -21,12 +21,9 @@ cd agentic-control-plane
 # Install pre-commit hooks (run once)
 pre-commit install
 
-# Install dependencies for a specific subproject
-cd tools/a2a_bridge_server
-uv sync --frozen --extra dev
-
-cd agents/k8s_debug_agent
-uv sync --frozen --extra dev
+# Install dependencies for a specific subproject (subshells keep you at repo root)
+(cd tools/a2a_bridge_server && uv sync --frozen --extra dev)
+(cd agents/k8s_debug_agent && uv sync --frozen --extra dev)
 ```
 
 ## Project Structure
@@ -48,12 +45,10 @@ Each subproject has its own test suite managed with `uv`:
 
 ```bash
 # a2a bridge server
-cd tools/a2a_bridge_server
-uv run pytest tests/ -v
+(cd tools/a2a_bridge_server && uv run pytest tests/ -v)
 
 # k8s debug agent
-cd agents/k8s_debug_agent
-uv run pytest tests/ -v
+(cd agents/k8s_debug_agent && uv run pytest tests/ -v)
 ```
 
 ## Running Lint and Format Checks
@@ -81,8 +76,8 @@ make fmt
 3. **Run checks locally** before pushing:
    ```bash
    pre-commit run --all-files
-   cd tools/a2a_bridge_server && uv run pytest tests/ -v
-   cd agents/k8s_debug_agent && uv run pytest tests/ -v
+   (cd tools/a2a_bridge_server && uv run pytest tests/ -v)
+   (cd agents/k8s_debug_agent && uv run pytest tests/ -v)
    ```
 
 4. **Commit** with a DCO sign-off (required — see below):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security vulnerabilities through GitHub Security Advisories:
+
+**[Report a vulnerability](https://github.com/kagenti/agentic-control-plane/security/advisories/new)**
+
+Include as much detail as possible:
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof-of-concept
+- Affected versions or components
+- Any suggested mitigations (optional)
+
+## Response Timeline
+
+| Stage | Target |
+|-------|--------|
+| Acknowledgment | Within 48 hours |
+| Initial assessment | Within 7 days |
+| Fix or mitigation | Based on severity (critical: ≤7 days, high: ≤30 days) |
+| Public disclosure | Coordinated with reporter after fix is available |
+
+## Security Controls
+
+This repository employs the following security measures:
+
+- **CI security scanning**: Trivy (filesystem + IaC), CodeQL, Bandit (Python SAST)
+- **Dependency updates**: Dependabot monitors GitHub Actions, pip, and Docker dependencies weekly
+- **OpenSSF Scorecard**: Weekly supply-chain health reporting
+- **Pre-commit hooks**: Local lint and format checks before commits reach CI
+- **Action pinning**: All GitHub Actions are pinned to full commit SHAs
+- **Least-privilege CI**: Each workflow job declares only the permissions it needs
+
+## Supported Versions
+
+This project is under active development. Security fixes are applied to the
+latest version on the `main` branch.
+
+## Scope
+
+In-scope for vulnerability reports:
+- Source code in `agents/`, `tools/`
+- CI/CD workflow configurations in `.github/workflows/`
+- Kubernetes manifests in `deploy/`
+
+Out of scope:
+- Vulnerabilities in third-party dependencies (report upstream; Dependabot will track these)
+- Issues already publicly disclosed in the [Security Advisories](https://github.com/kagenti/agentic-control-plane/security/advisories)


### PR DESCRIPTION
## Summary

Phase 5 of repo orchestration — security governance files.

- **CODEOWNERS**: `@kagenti/maintainers` auto-requested on all PRs, with explicit entries for `agents/`, `tools/`, `deploy/`, `.github/`, and docs.
- **SECURITY.md**: Vulnerability reporting via GitHub Security Advisories (private disclosure), 48h acknowledgment SLA, and an up-to-date list of active security controls (Trivy, CodeQL, Bandit, Dependabot, Scorecard, action pinning) added in PR #17.
- **CONTRIBUTING.md**: Development setup with `uv`, per-subproject test commands, PR process, conventional commit reference, and DCO sign-off instructions.
- **.gitignore**: Added missing secret/credential patterns (`*.key`, `*.pem`, `kubeconfig`, `credentials.*`, `secrets.*`).
- **LICENSE**: Apache 2.0 already present — no change needed.

## Branch protection recommendations

The following settings are recommended for the `main` branch
(Settings → Branches → Branch protection rules):

| Rule | Value |
|------|-------|
| Require a pull request before merging | ✅ |
| Required approvals | 1 |
| Require status checks to pass | `Lint`, `Test / a2a-bridge-server`, `Test / k8s-debug-agent`, `Python Security (Bandit)`, `Trivy Filesystem Scan`, `CodeQL Analysis`, `DCO` |
| Require branches to be up to date | ✅ |
| Require conversation resolution before merging | ✅ |
| Restrict force pushes | ✅ |
| Allow deletions | ❌ |

## Test plan

- [ ] CODEOWNERS syntax is valid (GitHub shows reviewer assignments on new PRs)
- [ ] SECURITY.md advisory link resolves correctly
- [ ] CONTRIBUTING.md development setup steps work end-to-end
- [ ] `.gitignore` additions don't accidentally exclude legitimate tracked files