### PR TITLE
build(deps): Bump python base image to 3.14-slim

### DIFF
--- a/agents/k8s_debug_agent/Dockerfile
+++ b/agents/k8s_debug_agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/tools/a2a_bridge_server/Dockerfile
+++ b/tools/a2a_bridge_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim 
+FROM python:3.14-slim 
 
 WORKDIR /app
 

--- a/tools/k8s_readonly_server/Dockerfile
+++ b/tools/k8s_readonly_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Bumps the Python base image to `3.14-slim` across all Dockerfiles:
  - `agents/k8s_debug_agent/Dockerfile` (3.12 → 3.14)
  - `tools/a2a_bridge_server/Dockerfile` (3.12 → 3.14)
  - `tools/k8s_readonly_server/Dockerfile` (3.11 → 3.14)

## Bundled PRs

Supersedes individual Dependabot PRs:
- #18 — `tools/a2a_bridge_server`
- #19 — `tools/k8s_readonly_server`
- #20 — `agents/k8s_debug_agent`

## Test plan

- [ ] CI passes (lint, tests, security scans, Dockerfile lint)
- [ ] Verify container images build successfully with Python 3.14
- [ ] Validate no runtime regressions from Python version jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)