### PR TITLE
docs: Fix broken A2A protocol repo link

### DIFF
--- a/tools/a2a_bridge_server/README.md
+++ b/tools/a2a_bridge_server/README.md
@@ -1,6 +1,6 @@
 # A2A Bridge MCP Server
 
-An MCP (Model Context Protocol) server that bridges MCP clients (like Claude, coding assistants, and other agents) to [A2A-compliant agents](https://github.com/a2a-protocol/a2a-protocol) running in Kubernetes clusters managed by Kagenti.
+An MCP (Model Context Protocol) server that bridges MCP clients (like Claude, coding assistants, and other agents) to [A2A-compliant agents](https://github.com/a2aproject/A2A) running in Kubernetes clusters managed by Kagenti.
 
 ## What is this?
 


### PR DESCRIPTION
## Summary

- Update A2A protocol GitHub link from defunct `a2a-protocol/a2a-protocol` to current `a2aproject/A2A`
- The project moved from Google to the Linux Foundation (a2aproject org)

## Related issue(s)

- kagenti/kagenti#1694 (parent link-health effort)

Assisted-By: Claude Code